### PR TITLE
Run Gnosis deployment only on merge to main

### DIFF
--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -1,9 +1,6 @@
 name: Deploy to Gnosis Chain
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger from Gnosis deployment workflow
- Deployment now only runs on push to main (i.e., when PRs are merged)

## Test plan
- [ ] Verify workflow does not run on PR creation
- [ ] Verify workflow runs after PR is merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)