### PR TITLE
Add mainnet configuration with daily chore schedules

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,0 +1,28 @@
+{
+  "network": "mainnet",
+  "chainId": 1,
+  "collateralToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  "requiredCollateral": "1000000000000000000",
+  "chores": [
+    {
+      "title": "washing the dishes",
+      "frequency": 86400,
+      "description": "Daily chore"
+    },
+    {
+      "title": "tidying up the shower room and laundry area",
+      "frequency": 86400,
+      "description": "Daily chore"
+    },
+    {
+      "title": "cleaning the upstairs food area",
+      "frequency": 86400,
+      "description": "Daily chore"
+    },
+    {
+      "title": "cleaning the tables and floor after dinner",
+      "frequency": 86400,
+      "description": "Daily chore"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add mainnet.json configuration file for Ethereum mainnet deployment
- Configure required collateral of 1e18 (1 ETH)
- Define 4 daily chore schedules:
  - Washing the dishes
  - Tidying up shower room and laundry area
  - Cleaning upstairs food area
  - Cleaning tables and floor after dinner

## Test plan
- [ ] Review mainnet configuration values
- [ ] Verify collateral amount is correct (1e18)
- [ ] Confirm daily chore schedules are appropriate
- [ ] Validate JSON structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)