### PR TITLE
Add invite generation utilities and tests

### DIFF
--- a/script/InviteGenerator.s.sol
+++ b/script/InviteGenerator.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+
+/// @title InviteGenerator
+/// @notice Utility for generating invite signatures for CommuneOS
+/// @dev This is a script/utility contract, not deployed on-chain
+contract InviteGenerator is Script {
+    /// @notice Generates an invite signature for a commune
+    /// @param privateKey The creator's private key
+    /// @param communeId The commune ID to generate invite for
+    /// @param nonce Unique nonce for this invite
+    /// @return signature The generated signature bytes
+    /// @dev Uses EIP-191 signing format to match CommuneRegistry validation
+    function generateInvite(uint256 privateKey, uint256 communeId, uint256 nonce)
+        public
+        pure
+        returns (bytes memory signature)
+    {
+        // Create the message hash (same as CommuneRegistry.getMessageHash)
+        bytes32 messageHash = keccak256(abi.encodePacked(communeId, nonce));
+
+        // Convert to Ethereum signed message hash (EIP-191)
+        bytes32 ethSignedMessageHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
+        );
+
+        // Sign the message
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedMessageHash);
+
+        // Combine into signature bytes
+        signature = abi.encodePacked(r, s, v);
+
+        return signature;
+    }
+
+    /// @notice Batch generates multiple invite signatures
+    /// @param privateKey The creator's private key
+    /// @param communeId The commune ID to generate invites for
+    /// @param nonces Array of unique nonces for the invites
+    /// @return signatures Array of generated signature bytes
+    function generateInvites(uint256 privateKey, uint256 communeId, uint256[] memory nonces)
+        public
+        pure
+        returns (bytes[] memory signatures)
+    {
+        signatures = new bytes[](nonces.length);
+        for (uint256 i = 0; i < nonces.length; i++) {
+            signatures[i] = generateInvite(privateKey, communeId, nonces[i]);
+        }
+        return signatures;
+    }
+
+    /// @notice Helper to derive address from private key
+    /// @param privateKey The private key
+    /// @return addr The corresponding address
+    function getAddressFromPrivateKey(uint256 privateKey) public pure returns (address addr) {
+        return vm.addr(privateKey);
+    }
+}

--- a/script/README_INVITES.md
+++ b/script/README_INVITES.md
@@ -1,0 +1,129 @@
+# Invite Generator Utility
+
+## Overview
+
+The `InviteGenerator` is a Solidity utility contract for generating cryptographic signatures that allow new members to join CommuneOS communes. It uses EIP-191 signature format to create secure, single-use invites.
+
+## Usage
+
+### Importing the Utility
+
+```solidity
+import "./InviteGenerator.s.sol";
+
+InviteGenerator inviteGenerator = new InviteGenerator();
+```
+
+### Generating a Single Invite
+
+```solidity
+uint256 creatorPrivateKey = 0xYourPrivateKey; // Keep this secret!
+uint256 communeId = 1;
+uint256 nonce = 1; // Must be unique for each invite
+
+bytes memory signature = inviteGenerator.generateInvite(
+    creatorPrivateKey,
+    communeId,
+    nonce
+);
+```
+
+### Generating Multiple Invites
+
+```solidity
+uint256[] memory nonces = new uint256[](3);
+nonces[0] = 1;
+nonces[1] = 2;
+nonces[2] = 3;
+
+bytes[] memory signatures = inviteGenerator.generateInvites(
+    creatorPrivateKey,
+    communeId,
+    nonces
+);
+```
+
+### Using the Invite to Join a Commune
+
+Once you have a signature, share it with the person you want to invite:
+
+```solidity
+// Member receives the signature and nonce
+communeOS.joinCommune(communeId, nonce, signature);
+```
+
+## Important Notes
+
+### Security Considerations
+
+1. **Private Key Protection**: Never expose your private key. This utility is meant for testing and script usage, not production key management.
+
+2. **Nonce Uniqueness**: Each nonce can only be used once. After a member joins using a nonce, that nonce is marked as used and cannot be reused.
+
+3. **Commune Specificity**: Signatures are bound to a specific commune ID. A signature for commune 1 cannot be used to join commune 2.
+
+4. **Creator Verification**: Only signatures from the commune creator are valid. The system verifies that the signature was created by the commune's original creator.
+
+### Best Practices
+
+1. **Sequential Nonces**: Use sequential nonces (1, 2, 3...) for easier tracking.
+
+2. **Secure Distribution**: Share invites (communeId, nonce, signature) through secure channels.
+
+3. **Batch Generation**: When onboarding multiple members, generate all invites at once using `generateInvites()` for efficiency.
+
+## Helper Functions
+
+### Get Address from Private Key
+
+```solidity
+address creatorAddress = inviteGenerator.getAddressFromPrivateKey(creatorPrivateKey);
+```
+
+This helps verify which address corresponds to a private key before generating invites.
+
+## Example: Complete Invite Flow
+
+```solidity
+// 1. Creator creates a commune
+uint256 communeId = communeOS.createCommune("My Commune", true, 1 ether, schedules);
+
+// 2. Creator generates invites for 3 new members
+uint256[] memory nonces = new uint256[](3);
+nonces[0] = 1;
+nonces[1] = 2;
+nonces[2] = 3;
+
+bytes[] memory invites = inviteGenerator.generateInvites(
+    creatorPrivateKey,
+    communeId,
+    nonces
+);
+
+// 3. Share invite data with each member:
+//    - Member 1: communeId, nonces[0], invites[0]
+//    - Member 2: communeId, nonces[1], invites[1]
+//    - Member 3: communeId, nonces[2], invites[2]
+
+// 4. Each member joins
+// (Member 1)
+token.approve(address(communeOS.collateralManager()), 1 ether);
+communeOS.joinCommune(communeId, nonces[0], invites[0]);
+```
+
+## Testing
+
+The utility includes comprehensive tests in `test/InviteGenerator.t.sol`:
+
+```bash
+forge test --match-contract InviteGeneratorTest -vv
+```
+
+Tests cover:
+- Single invite generation
+- Batch invite generation
+- Invalid signer rejection
+- Nonce reuse prevention
+- Commune-specific validation
+- Address derivation
+- Message hash format verification

--- a/test/InviteGenerator.t.sol
+++ b/test/InviteGenerator.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../script/InviteGenerator.s.sol";
+import "../src/CommuneOS.sol";
+import "../src/interfaces/ICommuneOS.sol";
+import {Commune} from "../src/interfaces/ICommuneRegistry.sol";
+import {ChoreSchedule} from "../src/interfaces/IChoreScheduler.sol";
+import "./MockERC20.sol";
+
+/// @title InviteGeneratorTest
+/// @notice Tests for the InviteGenerator utility to ensure invite signatures work correctly
+contract InviteGeneratorTest is Test {
+    InviteGenerator public inviteGenerator;
+    CommuneOS public communeOS;
+    MockERC20 public token;
+
+    uint256 public creatorPrivateKey = 0xABCDEF;
+    uint256 public member1PrivateKey = 0x123456;
+    uint256 public member2PrivateKey = 0x789012;
+
+    address public creator;
+    address public member1;
+    address public member2;
+
+    uint256 public constant COLLATERAL_AMOUNT = 5 ether;
+
+    function setUp() public {
+        inviteGenerator = new InviteGenerator();
+        token = new MockERC20();
+        communeOS = new CommuneOS(address(token));
+
+        creator = vm.addr(creatorPrivateKey);
+        member1 = vm.addr(member1PrivateKey);
+        member2 = vm.addr(member2PrivateKey);
+
+        // Mint tokens
+        token.mint(creator, 1000 ether);
+        token.mint(member1, 1000 ether);
+        token.mint(member2, 1000 ether);
+    }
+
+    /// @notice Test generating a single invite and using it to join a commune
+    function testGenerateSingleInvite() public {
+        // Create commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        uint256 communeId = communeOS.createCommune("Test Commune", true, COLLATERAL_AMOUNT, schedules);
+        vm.stopPrank();
+
+        // Generate invite using utility
+        uint256 nonce = 1;
+        bytes memory signature = inviteGenerator.generateInvite(creatorPrivateKey, communeId, nonce);
+
+        // Verify signature is 65 bytes
+        assertEq(signature.length, 65, "Signature should be 65 bytes");
+
+        // Member1 joins with generated invite
+        vm.startPrank(member1);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        communeOS.joinCommune(communeId, nonce, signature);
+        vm.stopPrank();
+
+        // Verify member joined successfully
+        (, uint256 memberCount,,) = communeOS.getCommuneStatistics(communeId);
+        assertEq(memberCount, 2, "Should have 2 members");
+
+        address[] memory members = communeOS.getCommuneMembers(communeId);
+        assertEq(members[0], creator, "First member should be creator");
+        assertEq(members[1], member1, "Second member should be member1");
+    }
+
+    /// @notice Test generating multiple invites in batch
+    function testGenerateBatchInvites() public {
+        // Create commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        uint256 communeId = communeOS.createCommune("Test Commune", true, COLLATERAL_AMOUNT, schedules);
+        vm.stopPrank();
+
+        // Generate multiple invites
+        uint256[] memory nonces = new uint256[](2);
+        nonces[0] = 1;
+        nonces[1] = 2;
+
+        bytes[] memory signatures = inviteGenerator.generateInvites(creatorPrivateKey, communeId, nonces);
+
+        // Verify we got 2 signatures
+        assertEq(signatures.length, 2, "Should have 2 signatures");
+        assertEq(signatures[0].length, 65, "First signature should be 65 bytes");
+        assertEq(signatures[1].length, 65, "Second signature should be 65 bytes");
+
+        // Member1 joins with first invite
+        vm.startPrank(member1);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        communeOS.joinCommune(communeId, nonces[0], signatures[0]);
+        vm.stopPrank();
+
+        // Member2 joins with second invite
+        vm.startPrank(member2);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        communeOS.joinCommune(communeId, nonces[1], signatures[1]);
+        vm.stopPrank();
+
+        // Verify both members joined
+        (, uint256 memberCount,,) = communeOS.getCommuneStatistics(communeId);
+        assertEq(memberCount, 3, "Should have 3 members");
+    }
+
+    /// @notice Test that invite from wrong private key fails
+    function testInvalidSignerFails() public {
+        // Create commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        uint256 communeId = communeOS.createCommune("Test Commune", true, COLLATERAL_AMOUNT, schedules);
+        vm.stopPrank();
+
+        // Generate invite with wrong private key (not creator)
+        uint256 nonce = 1;
+        bytes memory invalidSignature = inviteGenerator.generateInvite(member1PrivateKey, communeId, nonce);
+
+        // Try to join with invalid signature - should fail
+        vm.startPrank(member1);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        vm.expectRevert(ICommuneOS.InvalidInvite.selector);
+        communeOS.joinCommune(communeId, nonce, invalidSignature);
+        vm.stopPrank();
+    }
+
+    /// @notice Test that reusing the same nonce fails
+    function testNonceReuseFails() public {
+        // Create commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        uint256 communeId = communeOS.createCommune("Test Commune", true, COLLATERAL_AMOUNT, schedules);
+        vm.stopPrank();
+
+        // Generate invite
+        uint256 nonce = 1;
+        bytes memory signature = inviteGenerator.generateInvite(creatorPrivateKey, communeId, nonce);
+
+        // Member1 joins
+        vm.startPrank(member1);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        communeOS.joinCommune(communeId, nonce, signature);
+        vm.stopPrank();
+
+        // Try to reuse same nonce - should fail
+        vm.startPrank(member2);
+        token.approve(address(communeOS.collateralManager()), COLLATERAL_AMOUNT);
+        vm.expectRevert(); // Will revert with NonceAlreadyUsed
+        communeOS.joinCommune(communeId, nonce, signature);
+        vm.stopPrank();
+    }
+
+    /// @notice Test that invites are commune-specific
+    function testInviteIsCommuneSpecific() public {
+        // Create first commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        uint256 communeId1 = communeOS.createCommune("Test Commune 1", false, 0, schedules);
+        vm.stopPrank();
+
+        // Create second commune with different creator (member2)
+        vm.startPrank(member2);
+        uint256 communeId2 = communeOS.createCommune("Test Commune 2", false, 0, schedules);
+        vm.stopPrank();
+
+        // Generate invite for commune 1 from creator
+        uint256 nonce = 1;
+        bytes memory signature = inviteGenerator.generateInvite(creatorPrivateKey, communeId1, nonce);
+
+        // Try to use invite for commune 1 to join commune 2 - should fail
+        // (signature is from creator, but member2 is the creator of commune 2)
+        vm.startPrank(member1);
+        vm.expectRevert(ICommuneOS.InvalidInvite.selector);
+        communeOS.joinCommune(communeId2, nonce, signature);
+        vm.stopPrank();
+    }
+
+    /// @notice Test getAddressFromPrivateKey helper
+    function testGetAddressFromPrivateKey() public {
+        address derivedAddress = inviteGenerator.getAddressFromPrivateKey(creatorPrivateKey);
+        assertEq(derivedAddress, creator, "Derived address should match creator");
+
+        address derivedMember1 = inviteGenerator.getAddressFromPrivateKey(member1PrivateKey);
+        assertEq(derivedMember1, member1, "Derived address should match member1");
+    }
+
+    /// @notice Test invite generation without collateral requirement
+    function testInviteWithoutCollateral() public {
+        // Create commune without collateral
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        uint256 communeId = communeOS.createCommune("No Collateral Commune", false, 0, schedules);
+        vm.stopPrank();
+
+        // Generate invite
+        uint256 nonce = 1;
+        bytes memory signature = inviteGenerator.generateInvite(creatorPrivateKey, communeId, nonce);
+
+        // Member joins without needing to approve collateral
+        vm.startPrank(member1);
+        communeOS.joinCommune(communeId, nonce, signature);
+        vm.stopPrank();
+
+        // Verify member joined
+        (, uint256 memberCount,,) = communeOS.getCommuneStatistics(communeId);
+        assertEq(memberCount, 2, "Should have 2 members");
+
+        // Verify no collateral was deposited
+        uint256 collateral = communeOS.getCollateralBalance(member1);
+        assertEq(collateral, 0, "Member should have no collateral");
+    }
+
+    /// @notice Test generating many invites at once
+    function testGenerateManyInvites() public {
+        // Create commune
+        vm.startPrank(creator);
+        ChoreSchedule[] memory schedules = new ChoreSchedule[](0);
+        uint256 communeId = communeOS.createCommune("Test Commune", false, 0, schedules);
+        vm.stopPrank();
+
+        // Generate 10 invites
+        uint256[] memory nonces = new uint256[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            nonces[i] = i + 1;
+        }
+
+        bytes[] memory signatures = inviteGenerator.generateInvites(creatorPrivateKey, communeId, nonces);
+
+        // Verify we got 10 valid signatures
+        assertEq(signatures.length, 10, "Should have 10 signatures");
+
+        for (uint256 i = 0; i < 10; i++) {
+            assertEq(signatures[i].length, 65, "Each signature should be 65 bytes");
+            // Verify each signature is different
+            if (i > 0) {
+                assertTrue(
+                    keccak256(signatures[i]) != keccak256(signatures[i-1]),
+                    "Signatures should be unique"
+                );
+            }
+        }
+    }
+
+    /// @notice Test that the message hash format matches CommuneRegistry
+    function testMessageHashFormat() public {
+        uint256 communeId = 123;
+        uint256 nonce = 456;
+
+        // Generate signature
+        bytes memory signature = inviteGenerator.generateInvite(creatorPrivateKey, communeId, nonce);
+
+        // Manually verify the hash format matches
+        bytes32 messageHash = keccak256(abi.encodePacked(communeId, nonce));
+        bytes32 ethSignedMessageHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
+        );
+
+        // Recover signer from our signature
+        (bytes32 r, bytes32 s, uint8 v) = splitSignature(signature);
+        address recoveredSigner = ecrecover(ethSignedMessageHash, v, r, s);
+
+        // Verify recovered signer matches creator
+        assertEq(recoveredSigner, creator, "Recovered signer should match creator");
+    }
+
+    // Helper to split signature (same as CommuneRegistry)
+    function splitSignature(bytes memory sig) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
+        require(sig.length == 65, "Invalid signature length");
+
+        assembly {
+            r := mload(add(sig, 32))
+            s := mload(add(sig, 64))
+            v := byte(0, mload(add(sig, 96)))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds utilities for generating invite signatures and comprehensive tests to verify the invite system works correctly.

## Changes

### New Files

1. **`script/InviteGenerator.s.sol`** - Utility contract for generating invite signatures
   - `generateInvite(privateKey, communeId, nonce)` - Generate single invite
   - `generateInvites(privateKey, communeId, nonces)` - Batch generate invites
   - `getAddressFromPrivateKey(privateKey)` - Helper to derive addresses

2. **`test/InviteGenerator.t.sol`** - Comprehensive test suite
   - ✅ Single invite generation and usage
   - ✅ Batch invite generation (multiple members)
   - ✅ Invalid signer rejection
   - ✅ Nonce reuse prevention
   - ✅ Commune-specific validation
   - ✅ Collateral and non-collateral flows
   - ✅ Address derivation helper
   - ✅ Message hash format verification
   - ✅ Large batch generation (10 invites)

3. **`script/README_INVITES.md`** - Documentation
   - Usage examples
   - Security considerations
   - Best practices
   - Complete invite flow examples

## Test Results

All tests passing (17/17):
- 9 new InviteGenerator tests
- 8 existing CommuneOS tests still passing

```
Ran 2 test suites: 17 tests passed, 0 failed
```

## Technical Details

- Uses EIP-191 signature format to match CommuneRegistry validation
- Signatures are 65 bytes (r, s, v components)
- Each nonce can only be used once per commune
- Signatures are commune-specific (cannot be reused across communes)
- Accepts private key as uint256 for use in Foundry scripts

## Usage Example

```solidity
InviteGenerator generator = new InviteGenerator();

// Generate invite
uint256 nonce = 1;
bytes memory signature = generator.generateInvite(
    creatorPrivateKey,
    communeId,
    nonce
);

// Share with new member
// Member joins with: communeOS.joinCommune(communeId, nonce, signature);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)