### PR TITLE
Configure workflow triggers for deployment pipelines

### DIFF
--- a/.github/workflows/deploy-gnosis.yml
+++ b/.github/workflows/deploy-gnosis.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,12 +1,9 @@
 name: Deploy to Holesky Testnet
 
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
-      - dev
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Configure Holesky workflow to run on PRs to main (for testing in PR environment)
- Configure Gnosis workflow to run only on merge to main (for production deployments)

## Changes
- **Holesky workflow**: Removed push trigger to `dev`, now only runs on `pull_request` to `main`
- **Gnosis workflow**: Removed `pull_request` trigger, now only runs on `push` to `main`

## Test plan
- [ ] Verify Holesky workflow runs when this PR is opened
- [ ] Verify Gnosis workflow does not run on this PR
- [ ] After merge, verify Gnosis workflow runs on the merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)