### PR TITLE
Fix forge build warnings

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -27,8 +27,6 @@ contract DeployScript is Script {
             choresJson = string(choresData);
         } catch {}
 
-        address deployer = vm.addr(deployerPrivateKey);
-
         vm.startBroadcast(deployerPrivateKey);
 
         // Deploy CommuneOS

--- a/src/ChoreScheduler.sol
+++ b/src/ChoreScheduler.sol
@@ -162,13 +162,12 @@ contract ChoreScheduler is CommuneOSModule, IChoreScheduler {
     }
 
     /// @notice Calculate which member index is assigned to a chore in a given period
-    /// @param communeId The commune ID
     /// @param choreId The chore ID
     /// @param period The period number
     /// @param memberCount Total number of members
     /// @return uint256 The index of the assigned member (rotation)
     /// @dev Uses formula: (choreId + period) % memberCount for deterministic rotation
-    function getAssignedMemberIndex(uint256 communeId, uint256 choreId, uint256 period, uint256 memberCount)
+    function getAssignedMemberIndex(uint256 choreId, uint256 period, uint256 memberCount)
         external
         pure
         returns (uint256)

--- a/src/interfaces/IChoreScheduler.sol
+++ b/src/interfaces/IChoreScheduler.sol
@@ -54,7 +54,7 @@ interface IChoreScheduler {
         view
         returns (address);
 
-    function getAssignedMemberIndex(uint256 communeId, uint256 choreId, uint256 period, uint256 memberCount)
+    function getAssignedMemberIndex(uint256 choreId, uint256 period, uint256 memberCount)
         external
         pure
         returns (uint256);

--- a/test/CommuneOS.t.sol
+++ b/test/CommuneOS.t.sol
@@ -205,9 +205,9 @@ contract CommuneOSTest is Test {
         vm.stopPrank();
 
         // Add members with collateral
-        _addMemberWithCollateral(creator, communeId, member1, 1);
-        _addMemberWithCollateral(creator, communeId, member2, 2);
-        _addMemberWithCollateral(creator, communeId, member3, 3);
+        _addMemberWithCollateral(communeId, member1, 1);
+        _addMemberWithCollateral(communeId, member2, 2);
+        _addMemberWithCollateral(communeId, member3, 3);
 
         // Create expense assigned to member1
         vm.startPrank(creator);
@@ -300,7 +300,7 @@ contract CommuneOSTest is Test {
     }
 
     // Helper function to add members with collateral
-    function _addMemberWithCollateral(address _creator, uint256 communeId, address member, uint256 nonce) internal {
+    function _addMemberWithCollateral(uint256 communeId, address member, uint256 nonce) internal {
         bytes32 messageHash = keccak256(abi.encodePacked(communeId, nonce));
         bytes32 ethSignedMessageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(creatorPrivateKey, ethSignedMessageHash);

--- a/test/InviteGenerator.t.sol
+++ b/test/InviteGenerator.t.sol
@@ -185,7 +185,7 @@ contract InviteGeneratorTest is Test {
     }
 
     /// @notice Test getAddressFromPrivateKey helper
-    function testGetAddressFromPrivateKey() public {
+    function testGetAddressFromPrivateKey() public view {
         address derivedAddress = inviteGenerator.getAddressFromPrivateKey(creatorPrivateKey);
         assertEq(derivedAddress, creator, "Derived address should match creator");
 
@@ -248,7 +248,7 @@ contract InviteGeneratorTest is Test {
     }
 
     /// @notice Test that the message hash format matches CommuneRegistry
-    function testMessageHashFormat() public {
+    function testMessageHashFormat() public view {
         uint256 communeId = 123;
         uint256 nonce = 456;
 


### PR DESCRIPTION
## Summary
- Removed unused `communeId` parameter from `ChoreScheduler.getAssignedMemberIndex()`
- Removed unused `_creator` parameter from `CommuneOS.t.sol` helper function
- Removed unused `deployer` variable from deployment script
- Fixed function state mutability for test functions to `view`

## Test plan
- [x] Run `forge build` to verify no warnings
- [x] All changes are cleanup-only, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)