### PR TITLE
Add period parameter to markChoreComplete

### DIFF
--- a/src/ChoreScheduler.sol
+++ b/src/ChoreScheduler.sol
@@ -49,14 +49,14 @@ contract ChoreScheduler is CommuneOSModule, IChoreScheduler {
         }
     }
 
-    /// @notice Mark a chore as complete for the current period
+    /// @notice Mark a chore as complete for a specific period
     /// @param communeId The commune ID
     /// @param choreId The chore ID
-    /// @dev Automatically calculates the current period and marks it complete
-    function markChoreComplete(uint256 communeId, uint256 choreId) external onlyCommuneOS {
+    /// @param period The period number to mark complete
+    /// @dev Marks the specified period as complete
+    function markChoreComplete(uint256 communeId, uint256 choreId, uint256 period) external onlyCommuneOS {
         if (choreId >= choreSchedules[communeId].length) revert InvalidChoreId();
 
-        uint256 period = getCurrentPeriod(communeId, choreId);
         if (completions[communeId][choreId][period]) revert AlreadyCompleted();
 
         completions[communeId][choreId][period] = true;

--- a/src/CommuneOS.sol
+++ b/src/CommuneOS.sol
@@ -110,9 +110,10 @@ contract CommuneOS is CommuneViewer, ICommuneOS {
     /// @notice Mark a chore as complete
     /// @param communeId The commune ID
     /// @param choreId The chore ID
+    /// @param period The period number to mark complete
     /// @dev Caller must be a member of the commune
-    function markChoreComplete(uint256 communeId, uint256 choreId) external onlyMember(communeId) {
-        choreScheduler.markChoreComplete(communeId, choreId);
+    function markChoreComplete(uint256 communeId, uint256 choreId, uint256 period) external onlyMember(communeId) {
+        choreScheduler.markChoreComplete(communeId, choreId, period);
     }
 
     /// @notice Create an expense with direct assignment

--- a/src/interfaces/IChoreScheduler.sol
+++ b/src/interfaces/IChoreScheduler.sol
@@ -34,7 +34,7 @@ interface IChoreScheduler {
     // Functions
     function addChores(uint256 communeId, ChoreSchedule[] memory schedules) external;
 
-    function markChoreComplete(uint256 communeId, uint256 choreId) external;
+    function markChoreComplete(uint256 communeId, uint256 choreId, uint256 period) external;
 
     function getCurrentPeriod(uint256 communeId, uint256 choreId) external view returns (uint256);
 

--- a/src/interfaces/ICommuneOS.sol
+++ b/src/interfaces/ICommuneOS.sol
@@ -21,7 +21,7 @@ interface ICommuneOS {
 
     function addChores(uint256 communeId, ChoreSchedule[] memory choreSchedules) external;
 
-    function markChoreComplete(uint256 communeId, uint256 choreId) external;
+    function markChoreComplete(uint256 communeId, uint256 choreId, uint256 period) external;
 
     function createExpense(
         uint256 communeId,

--- a/test/CommuneOS.t.sol
+++ b/test/CommuneOS.t.sol
@@ -109,8 +109,8 @@ contract CommuneOSTest is Test {
 
         uint256 communeId = communeOS.createCommune("Test Commune", false, 0, schedules, "creator");
 
-        // Mark chore complete
-        communeOS.markChoreComplete(communeId, 0);
+        // Mark chore complete for period 0
+        communeOS.markChoreComplete(communeId, 0, 0);
 
         // Check completion
         (ChoreSchedule[] memory returnedSchedules, uint256[] memory periods, bool[] memory completed) =


### PR DESCRIPTION
## Summary
- Allow users to specify which period to mark complete instead of automatically calculating the current period
- Provides more flexibility for marking chores complete for specific time periods

## Changes
- Updated `markChoreComplete` signature in both interfaces (`ICommuneOS`, `IChoreScheduler`)
- Updated implementation in `ChoreScheduler.sol` to accept explicit period parameter
- Updated `CommuneOS.sol` wrapper to pass period parameter through
- Updated test to pass explicit period parameter

## Test plan
- [x] All existing tests pass
- [x] Build succeeds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)