### PR TITLE
Update Gnosis collateral amount

### DIFF
--- a/config/gnosis.json
+++ b/config/gnosis.json
@@ -3,7 +3,7 @@
   "chainId": 100,
   "frontendUrl": "https://www.share-house.fun",
   "collateralToken": "0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3",
-  "collateralAmount": "1000000000000000000",
+  "collateralAmount": "100000000000000000",
   "chores": [
     {
       "title": "washing the dishes (soaping)",


### PR DESCRIPTION
## Background
The collateral amount for Gnosis needs to be reduced from 1 'bread' to 0.1 'bread'.

## Changes
- Modified `config/gnosis.json`:
  - Changed `collateralAmount` from `"1000000000000000000"` to `"100000000000000000"`.

## Testing
- [ ] Verify that the new `collateralAmount` is correctly reflected in the Gnosis configuration.
