### PR TITLE
Restrict commune member removal to creator

### DIFF
--- a/src/CommuneOS.sol
+++ b/src/CommuneOS.sol
@@ -221,8 +221,14 @@ contract CommuneOS is CommuneViewer, ICommuneOS {
     /// @notice Remove a member from a commune
     /// @param communeId The commune ID
     /// @param memberAddress Address of the member to remove
-    /// @dev Caller must be a member of the commune. Withdraws all collateral. Chore assignments are automatically invalidated.
-    function removeMember(uint256 communeId, address memberAddress) external onlyMember(communeId) {
+    /// @dev Caller must be the creator of the commune. Withdraws all collateral. Chore assignments are automatically invalidated.
+    function removeMember(uint256 communeId, address memberAddress) external {
+        // Get commune details
+        Commune memory commune = communeRegistry.getCommune(communeId);
+
+        // Check if caller is the creator
+        if (msg.sender != commune.creator) revert NotCreator();
+
         // Withdraw all collateral (if any exists)
         collateralManager.withdrawCollateral(memberAddress);
 

--- a/src/interfaces/ICommuneOS.sol
+++ b/src/interfaces/ICommuneOS.sol
@@ -7,6 +7,7 @@ interface ICommuneOS {
     // Errors
     error InsufficientCollateral();
     error NotAMember();
+    error NotCreator();
 
     // Functions
     function createCommune(


### PR DESCRIPTION
## Changes
- `src/CommuneOS.sol`:
  - Removed `onlyMember` modifier from `removeMember` function.
  - Added a check to ensure `msg.sender` is the `commune.creator` before proceeding.
  - Reverted to reverting with `NotCreator()` if the caller is not the creator.
- `src/interfaces/ICommuneOS.sol`:
  - Added a new error `NotCreator()`.
- `test/CommuneOS.t.sol`:
  - Renamed `testCannotRemoveMemberIfNotMember` to `testCannotRemoveMemberIfNotCreator`.
  - Updated test logic to verify that non-creator members and non-members attempting to remove members now revert with `NotCreator()`.
